### PR TITLE
Add Arbitrum mocks

### DIFF
--- a/contracts/test/rinkeby/FakeArbitrumBridge.sol
+++ b/contracts/test/rinkeby/FakeArbitrumBridge.sol
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2021 Dai Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+pragma solidity 0.8.9;
+
+interface IFakeArbitrumInbox {
+  function bridge() external view returns (address);
+
+  function setBridge(address _bridge) external;
+}
+
+library Address {
+  function isContract(address account) internal view returns (bool) {
+    uint256 size;
+    // solhint-disable-next-line no-inline-assembly
+    assembly {
+      size := extcodesize(account)
+    }
+    return size > 0;
+  }
+}
+
+contract FakeArbitrumBridge {
+  using Address for address;
+
+  event OwnerUpdated(address newOwner);
+  event OutboxToggle(address indexed outbox, bool enabled);
+  event BridgeCallTriggered(
+    address indexed outbox,
+    address indexed destAddr,
+    uint256 amount,
+    bytes data
+  );
+
+  struct InOutInfo {
+    uint256 index;
+    bool allowed;
+  }
+  mapping(address => InOutInfo) private allowedOutboxesMap;
+  address[] public allowedOutboxList;
+
+  address public owner;
+  IFakeArbitrumInbox public immutable fakeInbox;
+
+  address public activeOutbox;
+
+  constructor(address _fakeInbox) {
+    owner = msg.sender;
+    fakeInbox = IFakeArbitrumInbox(_fakeInbox);
+  }
+
+  modifier onlyOwner() {
+    require(msg.sender == owner, "FakeArbitrumBridge/ONLY_OWNER");
+    _;
+  }
+
+  function setOwner(address newOwner) external onlyOwner {
+    owner = newOwner;
+    emit OwnerUpdated(newOwner);
+  }
+
+  function executeCall(
+    address destAddr,
+    uint256 amount,
+    bytes calldata data
+  ) external returns (bool success, bytes memory returnData) {
+    require(allowedOutboxesMap[msg.sender].allowed, "FakeArbitrumBridge/NOT_FROM_OUTBOX");
+    if (data.length > 0) require(destAddr.isContract(), "FakeArbitrumBridge/NO_CODE_AT_DEST");
+
+    address prevBridge = fakeInbox.bridge();
+    if (prevBridge != address(this)) {
+      fakeInbox.setBridge(address(this));
+    }
+
+    address currentOutbox = activeOutbox;
+    activeOutbox = msg.sender;
+    // We set and reset active outbox around external call so activeOutbox remains valid during call
+    (success, returnData) = destAddr.call{value: amount}(data);
+    activeOutbox = currentOutbox;
+
+    if (prevBridge != address(this)) {
+      fakeInbox.setBridge(prevBridge);
+    }
+    emit BridgeCallTriggered(msg.sender, destAddr, amount, data);
+  }
+
+  function setOutbox(address outbox, bool enabled) external onlyOwner {
+    InOutInfo storage info = allowedOutboxesMap[outbox];
+    bool alreadyEnabled = info.allowed;
+    emit OutboxToggle(outbox, enabled);
+    if ((alreadyEnabled && enabled) || (!alreadyEnabled && !enabled)) {
+      return;
+    }
+    if (enabled) {
+      allowedOutboxesMap[outbox] = InOutInfo(allowedOutboxList.length, true);
+      allowedOutboxList.push(outbox);
+    } else {
+      allowedOutboxList[info.index] = allowedOutboxList[allowedOutboxList.length - 1];
+      allowedOutboxesMap[allowedOutboxList[info.index]].index = info.index;
+      allowedOutboxList.pop();
+      delete allowedOutboxesMap[outbox];
+    }
+  }
+}

--- a/contracts/test/rinkeby/FakeArbitrumInbox.sol
+++ b/contracts/test/rinkeby/FakeArbitrumInbox.sol
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2021 Dai Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+pragma solidity 0.8.9;
+
+contract FakeArbitrumInbox {
+  // --- Auth ---
+  mapping(address => uint256) public wards;
+
+  function rely(address usr) external auth {
+    wards[usr] = 1;
+    emit Rely(usr);
+  }
+
+  function deny(address usr) external auth {
+    wards[usr] = 0;
+    emit Deny(usr);
+  }
+
+  modifier auth() {
+    require(wards[msg.sender] == 1, "FakeArbitrumInbox/not-authorized");
+    _;
+  }
+
+  event Rely(address indexed usr);
+  event Deny(address indexed usr);
+  event BridgeSet(address indexed bridge);
+
+  address public bridge;
+
+  constructor(address _bridge) {
+    wards[msg.sender] = 1;
+    emit Rely(msg.sender);
+
+    bridge = _bridge;
+  }
+
+  /** @dev setBridge can be used to flip between using the real Bridge
+   * (controlled by the Outbox, which enforces a 7 days security window)
+   * and the FakeArbitrumBridge (which ignores the security window)
+   */
+  function setBridge(address _bridge) external auth {
+    bridge = _bridge;
+    emit BridgeSet(_bridge);
+  }
+
+  function createRetryableTicket(
+    address, /* destAddr */
+    uint256, /* arbTxCallValue */
+    uint256, /* maxSubmissionCost */
+    address, /* submissionRefundAddress */
+    address, /* valueRefundAddress */
+    uint256, /* maxGas */
+    uint256, /* gasPriceBid */
+    bytes calldata /* data */
+  ) external payable returns (uint256) {
+    // This fake inbox cannot be used to pass messages from L1 to L2
+    revert("FakeArbitrumInbox/createRetryableTicket-not-supported");
+  }
+
+  function createRetryableTicketNoRefundAliasRewrite(
+    address, /* destAddr */
+    uint256, /* arbTxCallValue */
+    uint256, /* maxSubmissionCost */
+    address, /* submissionRefundAddress */
+    address, /* valueRefundAddress */
+    uint256, /* maxGas */
+    uint256, /* gasPriceBid */
+    bytes calldata /* data */
+  ) external payable returns (uint256) {
+    // This fake inbox cannot be used to pass messages from L1 to L2
+    revert("FakeArbitrumInbox/createRetryableTicketNoRefundAliasRewrite-not-supported");
+  }
+}

--- a/contracts/test/rinkeby/FakeArbitrumOutbox.sol
+++ b/contracts/test/rinkeby/FakeArbitrumOutbox.sol
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2021 Dai Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+pragma solidity 0.8.9;
+
+interface IBridge {
+  function executeCall(
+    address destAddr,
+    uint256 amount,
+    bytes calldata data
+  ) external returns (bool success, bytes memory returnData);
+}
+
+contract FakeArbitrumOutbox {
+  event OutBoxTransactionExecuted(
+    address indexed destAddr,
+    address indexed l2Sender,
+    uint256 indexed outboxEntryIndex,
+    uint256 transactionIndex
+  );
+
+  struct L2ToL1Context {
+    uint128 l2Block;
+    uint128 l1Block;
+    uint128 timestamp;
+    uint128 batchNum;
+    bytes32 outputId;
+    address sender;
+  }
+
+  IBridge public bridge;
+
+  // Note, these variables are set and then wiped during a single transaction.
+  // Therefore their values don't need to be maintained, and their slots will
+  // be empty outside of transactions
+  L2ToL1Context internal context;
+
+  constructor(address _bridge) {
+    bridge = IBridge(_bridge);
+  }
+
+  /// @notice When l2ToL1Sender returns a nonzero address, the message was originated by an L2 account
+  /// When the return value is zero, that means this is a system message
+  /// @dev the l2ToL1Sender behaves as the tx.origin, the msg.sender should be validated to protect against reentrancies
+  function l2ToL1Sender() external view returns (address) {
+    return context.sender;
+  }
+
+  /**
+   * @notice Executes a L2>L1 message
+   * @dev [ArbitrumFakeOutbox] Ignore the dispute period
+   */
+
+  function executeTransaction(
+    uint256 batchNum,
+    bytes32[] memory, /* proof */
+    uint256 index,
+    address l2Sender,
+    address destAddr,
+    uint256 l2Block,
+    uint256 l1Block,
+    uint256 l2Timestamp,
+    uint256 amount,
+    bytes memory calldataForL1
+  ) external {
+    // [ArbitrumFakeOutbox] Skipped: merkle proof check & spent output recording
+
+    emit OutBoxTransactionExecuted(destAddr, l2Sender, batchNum, index);
+    // we temporarily store the previous values so the outbox can naturally
+    // unwind itself when there are nested calls to `executeTransaction`
+    L2ToL1Context memory prevContext = context;
+    context = L2ToL1Context({
+      sender: l2Sender,
+      l2Block: uint128(l2Block),
+      l1Block: uint128(l1Block),
+      timestamp: uint128(l2Timestamp),
+      batchNum: uint128(batchNum),
+      outputId: 0
+    });
+    // set and reset vars around execution so they remain valid during call
+    executeBridgeCall(destAddr, amount, calldataForL1);
+    context = prevContext;
+  }
+
+  function executeBridgeCall(
+    address destAddr,
+    uint256 amount,
+    bytes memory data
+  ) internal {
+    (bool success, bytes memory returndata) = bridge.executeCall(destAddr, amount, data);
+    if (!success) {
+      if (returndata.length > 0) {
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+          let returndata_size := mload(returndata)
+          revert(add(32, returndata), returndata_size)
+        }
+      } else {
+        revert("FakeArbitrumOutbox/BRIDGE_CALL_FAILED");
+      }
+    }
+  }
+}

--- a/deployment/deploy-rinkeby.ts
+++ b/deployment/deploy-rinkeby.ts
@@ -7,7 +7,7 @@ import { mapValues } from 'lodash'
 import { Dictionary } from 'ts-essentials'
 dotenv.config()
 
-import { ArbitrumBaseBridgeSdk, deployArbitrumWormholeBridge } from '../test/arbitrum'
+import { ArbitrumBaseBridgeSdk, deployArbitrumWormholeBridge, deployFakeArbitrumInbox } from '../test/arbitrum'
 import { ArbitrumRollupSdk } from '../test/arbitrum/sdk'
 import { deployWormhole } from '../test/wormhole'
 import { performSanityChecks } from '../test/wormhole/checks'
@@ -50,6 +50,9 @@ async function main() {
     globalFeeTTL: feeTTL,
   })
 
+  // Deploy a fake Arbitrum Inbox that allows relaying arbitrary L2>L1 messages without delay
+  const { fakeInbox } = await deployFakeArbitrumInbox({ l1Signer, arbitrumRollupSdk })
+
   const wormholeBridgeSdk = await deployArbitrumWormholeBridge({
     makerSdk: rinkebySdk.maker,
     l1Signer,
@@ -57,7 +60,7 @@ async function main() {
     wormholeSdk,
     baseBridgeSdk,
     slaveDomain: arbitrumSlaveDomain,
-    arbitrumRollupSdk,
+    arbitrumRollupSdk: { ...arbitrumRollupSdk, inbox: fakeInbox },
   })
 
   await performSanityChecks(

--- a/eth-sdk/config.ts
+++ b/eth-sdk/config.ts
@@ -77,9 +77,7 @@ export default defineConfig({
         l1DaiGateway: '0xb1cfD43BD287B2E94bf00140091A9Cca47f462cC',
       },
       arbitrum: {
-        fake_bridge: '0xc710c7eed1f6d29bc4251c1064f5b27824af72b8', // modified arbitrum bridge allowing arbitrary L2>L1 message passing without delay
         inbox: '0x578BAde599406A8fE3d24Fd7f7211c0911F5B29e', // real inbox
-        fake_inbox: '0x0495dF1ed467FeeCe56D36866acb3348BE407b9D', // modified inbox allowing arbitrary L2>L1 message passing without delay
       },
     },
 

--- a/scripts/copy-artifacts.js
+++ b/scripts/copy-artifacts.js
@@ -94,6 +94,9 @@ copyHardhatArtifact(join(hardhatTestArtifacts, 'test/PushBadDebtSpell.sol/PushBa
 copyHardhatArtifact(join(hardhatTestArtifacts, 'test/PushBadDebtSpell.sol/DaiJoinLike.json'), output)
 copyHardhatArtifact(join(hardhatTestArtifacts, 'test/PushBadDebtSpell.sol/VatLike.json'), output)
 copyHardhatArtifact(join(hardhatTestArtifacts, 'test/PushBadDebtSpell.sol/WormholeJoinLike.json'), output)
+copyHardhatArtifact(join(hardhatTestArtifacts, 'test/rinkeby/FakeArbitrumInbox.sol/FakeArbitrumInbox.json'), output)
+copyHardhatArtifact(join(hardhatTestArtifacts, 'test/rinkeby/FakeArbitrumBridge.sol/FakeArbitrumBridge.json'), output)
+copyHardhatArtifact(join(hardhatTestArtifacts, 'test/rinkeby/FakeArbitrumOutbox.sol/FakeArbitrumOutbox.json'), output)
 
 copyHardhatArtifact(
   join(hardhatTestArtifacts, 'deploy/L1AddWormholeOptimismSpell.sol/L1AddWormholeOptimismSpell.json'),

--- a/test/arbitrum/sdk.ts
+++ b/test/arbitrum/sdk.ts
@@ -1,3 +1,5 @@
 import { RinkebySdk } from '@dethcrypto/eth-sdk-client'
 
-export type ArbitrumRollupSdk = RinkebySdk['arbitrum']
+type RawArbitrumSdk = RinkebySdk['arbitrum']
+type InboxLike = Pick<RawArbitrumSdk['inbox'], 'bridge' | 'address'>
+export type ArbitrumRollupSdk = Omit<RawArbitrumSdk, 'inbox'> & { inbox: InboxLike }


### PR DESCRIPTION
Add mock Arbitrum Inbox, Bridge & Outbox with the following properties:
- the Arbitrum bridge used by the FakeArbitrumInbox can easily be changed to either the real Bridge (controlled by the real Outbox, which enforces a 7 days security window) or the FakeArbitrumBridge (which ignores the security window => useful for tests). This allows to use both the delayed and the instantaneous relay mechanisms to test the slow withdrawal path using the same L1WormholeBridge.
- L2 to L1 messages are relayed via the FakeArbitrumOutbox, using the same method signature as the one used with the real Outbox, but skipping the verification of the Merkle inclusion proof.